### PR TITLE
Cleanup string handling

### DIFF
--- a/lib/dotex.ex
+++ b/lib/dotex.ex
@@ -22,13 +22,13 @@ defmodule Dotex do
   defp generate_connections([]), do: ""
   defp generate_connections([{src, dst, params}|t]) when is_list(dst) do
     dstnames = dst
-    |> Enum.map(fn (d) -> d.name end)
+    |> Enum.map(fn (d) -> escape_name(d.name) end)
     |> Enum.join(", ")
 
-    ~s(  #{src.name} -> #{dstnames}#{generate_params(params)};\n) <> generate_connections(t)
+    ~s(  #{escape_name(src.name)} -> #{dstnames}#{generate_params(params)};\n) <> generate_connections(t)
   end
   defp generate_connections([{src, dst, params}|t]) do
-    ~s(  #{src.name} -> #{dst.name}#{generate_params(params)};\n)  <> generate_connections(t)
+    ~s(  #{escape_name(src.name)} -> #{escape_name(dst.name)}#{generate_params(params)};\n)  <> generate_connections(t)
   end
 
   defp generate_nodes([]), do: ""
@@ -36,11 +36,11 @@ defmodule Dotex do
     "" <> generate_nodes(t)
   end
   defp generate_nodes([%{name: name, params: params}|t]) do
-    "  #{name}#{generate_params(params)};\n" <> generate_nodes(t)
+    "  #{escape_name(name)}#{generate_params(params)};\n" <> generate_nodes(t)
   end
 
-  def generate_params(params) when params == %{}, do: ""
-  def generate_params(params) do
+  defp generate_params(params) when params == %{}, do: ""
+  defp generate_params(params) do
     param_string =
       params
       |> Enum.reverse
@@ -48,4 +48,6 @@ defmodule Dotex do
     |> Enum.join(",")
     " [#{param_string}]"
   end
+
+  defp escape_name(name) when is_binary(name), do: ~s("#{String.replace(name, ~s{"}, ~s(\\"))}")
 end

--- a/lib/dotex/node.ex
+++ b/lib/dotex/node.ex
@@ -1,6 +1,6 @@
 defmodule Dotex.Node do
   defstruct name: "", params: %{}
-  def new(name, params \\ %{}) do
+  def new(name, params \\ %{}) when is_binary(name) do
     %Dotex.Node{name: name, params: params}
   end
 end

--- a/test/dotex_test.exs
+++ b/test/dotex_test.exs
@@ -2,9 +2,9 @@ defmodule DotexTest do
   use ExUnit.Case
 
   test "simple digraph" do
-    a = Dotex.Node.new('A')
-    b = Dotex.Node.new('B')
-    c = Dotex.Node.new('C')
+    a = Dotex.Node.new("A")
+    b = Dotex.Node.new("B")
+    c = Dotex.Node.new("C")
 
     graph =
       Dotex.Graph.new
@@ -13,16 +13,16 @@ defmodule DotexTest do
       |> Dotex.graph
 
     assert graph == ~s(digraph {
-  A -> B;
-  B -> C, A;
+  "A" -> "B";
+  "B" -> "C", "A";
 }
 )
   end
 
   test "digraph with attributes" do
-    a = Dotex.Node.new('A', %{shape: "box"})
-    b = Dotex.Node.new('B')
-    c = Dotex.Node.new('C', %{style: "filled", fillcolor: "blue"})
+    a = Dotex.Node.new("A", %{shape: "box"})
+    b = Dotex.Node.new(~s{Node "B"})
+    c = Dotex.Node.new("C", %{style: "filled", fillcolor: "blue"})
 
     graph =
       Dotex.Graph.new
@@ -34,20 +34,20 @@ defmodule DotexTest do
       |> Dotex.Graph.add_connection(b, [c,a], %{label: "connections", arrowhead: "dot"})
       |> Dotex.graph
 
-    assert graph == ~s(digraph {
-  A [shape="box"];
-  C [style="filled",fillcolor="blue"];
-  A -> B;
-  C -> A [label="label"];
-  B -> C, A [label="connections",arrowhead="dot"];
+    assert graph == ~S(digraph {
+  "A" [shape="box"];
+  "C" [style="filled",fillcolor="blue"];
+  "A" -> "Node \"B\"";
+  "C" -> "A" [label="label"];
+  "Node \"B\"" -> "C", "A" [label="connections",arrowhead="dot"];
 }
 )
   end
 
   test "write graph to file" do
-    a = Dotex.Node.new('A')
-    b = Dotex.Node.new('B')
-    c = Dotex.Node.new('C')
+    a = Dotex.Node.new("A")
+    b = Dotex.Node.new("B")
+    c = Dotex.Node.new("C")
 
     :ok = Dotex.Graph.new
     |> Dotex.Graph.add_connection(a, b)


### PR DESCRIPTION
Add escaping of double quotes in node names so they don't cause
graphviz to crash.

Found some tests that used charlists instead of binaries so cleaned up
them as well